### PR TITLE
Fix Docker image to include OpenSSL and database scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
 # ---------- deps ----------
-FROM node:20-bookworm-slim AS deps
+FROM node:20-bullseye-slim AS deps
 WORKDIR /app
 COPY package*.json ./
+# Ensure OpenSSL 1.1 is available for Prisma
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 RUN npm ci
 
 # ---------- builder ----------
-FROM node:20-bookworm-slim AS builder
+FROM node:20-bullseye-slim AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+# Ensure OpenSSL 1.1 is available for Prisma client generation
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
 # Prisma client bør genereres i build stage
 RUN npx prisma generate
 RUN npm run build
 
 # ---------- runner ----------
-FROM node:20-bookworm-slim AS runner
+FROM node:20-bullseye-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+
+# Ensure OpenSSL 1.1 is available for Prisma client at runtime
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/package*.json ./
 COPY --from=builder /app/node_modules ./node_modules
@@ -25,6 +33,8 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/next.config.* ./
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/init-db.js ./
+COPY --from=builder /app/seed-db.js ./
 
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- switch all Docker stages to bullseye to provide OpenSSL 1.1.x support for Prisma
- install OpenSSL in build and runtime images and copy database init/seed scripts

## Testing
- not run (Docker build not executed in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695848c367948321b4927d824fa9b69c)