### PR TITLE
fix(programs): prevent empty 531 programs

### DIFF
--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -115,12 +115,22 @@ export default function ProgramsPage() {
     e.preventDefault()
 
     try {
-      const mainExercises = programMainExercises
-        .filter((ex) => ex.exerciseId && ex.oneRepMax > 0)
-        .map((ex) => ({
-          exerciseId: ex.exerciseId,
+      const resolvedMainExercises = programMainExercises.map((ex, index) => {
+        const exerciseId =
+          ex.exerciseId || exercises.find((exercise) => exercise.name === MAIN_LIFTS[index])?.id || ''
+
+        return {
+          exerciseId,
           oneRepMax: ex.oneRepMax,
-        }))
+        }
+      })
+
+      const mainExercises = resolvedMainExercises.filter((ex) => ex.exerciseId && ex.oneRepMax > 0)
+
+      if (programType === '531' && mainExercises.length === 0) {
+        alert('Legg til 1RM for minst én av hovedløftene før du lagrer programmet.')
+        return
+      }
 
       const accessoryExercises = programAccessoryExercises
         .filter((ex) => ex.exerciseId && ex.sets > 0 && ex.reps > 0)


### PR DESCRIPTION
## Summary
- ensure main lifts resolve to real exercise IDs before saving 5/3/1 programs
- block saving when no 1RM values are provided so generated programs are not empty

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585b199d088321b775846f7f202f93)